### PR TITLE
Add snap packaging

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,15 @@
+name: snap
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  snap:
+    uses: ubuntu-robotics/snap_workflows/.github/workflows/snap.yaml@main
+    with:
+      snap-name: mcap-editor
+      publish: true

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -13,3 +13,5 @@ jobs:
     with:
       snap-name: mcap-editor
       publish: true
+      branch-name: main
+      snap-install-args: --dangerous

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,3 +57,8 @@ target_include_directories(mcap_editor PRIVATE
 if(COMPILING_TO_WASM)
   target_link_options(mcap_editor PUBLIC -sASYNCIFY -Os)
 endif()
+
+install(
+    TARGETS mcap_editor
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,56 @@
+name: mcap-editor
+adopt-info: mcap-editor
+summary: MCAP editor (GUI)
+description: |
+  A GUI to edit your MCAP files.
+
+issues: https://github.com/facontidavide/mcap_editor/issues
+source-code: https://github.com/facontidavide/mcap_editor
+license: MIT
+
+confinement: strict
+base: core22
+
+apps:
+  mcap-editor:
+    command: usr/bin/mcap_editor
+    plugs:
+      - desktop
+      - desktop-legacy
+      - opengl
+      - wayland
+      - x11
+      - home
+      - removable-media
+    environment:
+      QT_PLUGIN_PATH: ${SNAP}/usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/qt6/plugins/
+
+parts:
+  mcap-editor:
+    plugin: cmake
+    source: .
+    cmake-parameters:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/usr
+    build-packages:
+      - build-essential
+      - libgl1-mesa-dev
+      - libvulkan-dev
+      - libxkbcommon-dev
+      - qt6-base-dev
+    stage-packages:
+      - libqt6core6
+      - libqt6gui6
+      - libqt6widgets6
+      - libxkbcommon0
+      - qt6-qpa-plugins
+      - qt6-wayland
+    override-pull: |
+        craftctl default
+        git submodule update --init --recursive
+
+        git config --global --add safe.directory '*'
+        version="$(git describe --always --tags| sed -e 's/^v//;s/-/+git/;y/-/./')"
+        [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+        craftctl set version="$version"
+        craftctl set grade="$grade"


### PR DESCRIPTION
Add snap packaging together with the associated workflow.

The snap may be still a little rough but loading/saving mcap file works.
Let me know if you test it and find any issue.

The workflow will automatically publish the snap to the store if/once:
- you register the snap name `mcap-editor`
- create a store token as explained [here](https://github.com/snapcore/action-publish?tab=readme-ov-file#store-login)