### PR TITLE
fixes sorting by integer 'Count' column

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ qt_add_executable(mcap_editor
     src/mainwindow.ui
     src/mcap_impl.cpp
     src/bytearray_writable.hpp
+    src/widget_integer.hpp
     src/resources.qrc)
 
 target_link_libraries(mcap_editor PRIVATE

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,6 +1,7 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "bytearray_writable.hpp"
+#include "widget_integer.hpp"
 
 #include <QSettings>
 #include <QFileDialog>
@@ -236,7 +237,7 @@ void MainWindow::readMCAP(mcap::McapReader& reader)
         ui->tableTopics->setItem(row, 0, channel_item);
         ui->tableTopics->setItem(row, 1, new QTableWidgetItem(schema_name));
         ui->tableTopics->setItem(row, 2, new QTableWidgetItem(encoding));
-        ui->tableTopics->setItem(row, 3, new QTableWidgetItem(QString::number(msg_count)));
+        ui->tableTopics->setItem(row, 3, new QTableWidgetItemInteger(QString::number(msg_count)));
 
         schema_id_by_channel_[channel->topic] = channel->schemaId;
         channel_encoding_[channel->topic] = channel->messageEncoding;

--- a/src/widget_integer.hpp
+++ b/src/widget_integer.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+// Helper class for sorting integer widget items numerically
+
+#include <QTableWidget>
+
+class QTableWidgetItemInteger : public QTableWidgetItem
+{
+    public:
+
+        QTableWidgetItemInteger(const QString& s) : QTableWidgetItem(s) {}
+
+        bool operator <(const QTableWidgetItem& that) const
+        {
+            return (text().toInt() < that.text().toInt());
+        }
+};


### PR DESCRIPTION
Adds a new derived class of "QTableWidgetItem", which overloads the '<' operator to enable sorting of the rows in the main table by the 'Count' column using numerical comparisons instead of alphabetical. 